### PR TITLE
fix: omitted Get/Set ULimit functions from Windows builds

### DIFF
--- a/files/ulimit.go
+++ b/files/ulimit.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package files
 
 import (


### PR DESCRIPTION
Fixes #55 