### PR TITLE
fix: update `IsNil` function to exclude Array type check

### DIFF
--- a/helpers/reflect.go
+++ b/helpers/reflect.go
@@ -47,7 +47,7 @@ func IsNil(i interface{}) bool {
 		return true
 	}
 	switch reflect.TypeOf(i).Kind() {
-	case reflect.Ptr, reflect.Map, reflect.Array, reflect.Chan, reflect.Slice:
+	case reflect.Ptr, reflect.Map, reflect.Chan, reflect.Slice:
 		return reflect.ValueOf(i).IsNil()
 	}
 	return false


### PR DESCRIPTION
- Remove Array type from `IsNil` function checks
- Fixes `call of reflect.Value.IsNil on array Value` - https://github.com/turbot/steampipe-plugin-sdk/issues/320