### PR TITLE
perf: hoist IsFieldArray regex to package level

### DIFF
--- a/helpers/reflect.go
+++ b/helpers/reflect.go
@@ -79,16 +79,17 @@ func DereferencePointer(val interface{}) interface{} {
 		TODO: add support for multi-dimensional arrays
 	 	like - arr[1][2] arr[1][2][3] and so on..
 */
+var fieldArrayRe = regexp.MustCompile(`^(.*)\[(\d+)\]$`)
+
 func IsFieldArray(fieldName string) (string, int, bool) {
-	r := regexp.MustCompile(`^(.*)\[(\d+)\]$`)
-	captureGroups := r.FindStringSubmatch(fieldName)
+	captureGroups := fieldArrayRe.FindStringSubmatch(fieldName)
 	if len(captureGroups) == 0 {
 		return "", 0, false
 	}
 	arrayName := captureGroups[1]
 	// check if arrayName contains index and brackets - arr[12]
 	// this would indicate a multi-level array which we do not support at present
-	subGroups := r.FindStringSubmatch(arrayName)
+	subGroups := fieldArrayRe.FindStringSubmatch(arrayName)
 	if len(subGroups) > 0 {
 		return "", 0, false
 	}

--- a/helpers/reflect_test.go
+++ b/helpers/reflect_test.go
@@ -230,6 +230,16 @@ func TestIsFieldArray(t *testing.T) {
 	}
 }
 
+func BenchmarkIsFieldArray(b *testing.B) {
+	inputs := []string{"foo", "bar[3]", "baz[12]", "qux"}
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		for _, s := range inputs {
+			_, _, _ = IsFieldArray(s)
+		}
+	}
+}
+
 //// IsZero ////
 type GetIsZeroTest struct {
 	input    interface{}


### PR DESCRIPTION
## Summary

`helpers.IsFieldArray` was calling `regexp.MustCompile` on every invocation, even though the pattern is a compile-time constant and `*regexp.Regexp` is safe for concurrent use. The Steampipe SDK's transform pipeline calls `IsFieldArray` once per column-per-row (via `GetFieldValueFromInterface` → `GetNestedFieldValueFromInterface`), making this an O(rows × cols) allocator.

Profiling a Steampipe plugin under realistic load (3,200-row burst, `STEAMPIPE_PPROF` heap profile) attributed **~40% of cumulative heap allocations** (1.92 GB out of 4.74 GB) to this single line.

The fix hoists the compiled regex to a package-level `var`. No behavior change.

## Benchmark

`BenchmarkIsFieldArray` loops over 4 inputs (2 matching, 2 non-matching):

|        | ns/op | B/op   | allocs/op |
|--------|------:|-------:|----------:|
| Before |  9174 | 20386  |       188 |
| After  |   718 |   224  |         4 |

~13× faster, ~91× less memory, ~47× fewer allocs. Non-matching inputs are now zero-alloc; the residual 4 allocs come from `FindStringSubmatch` returning capture-group slices for the matching inputs.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./helpers/...` passes (existing `TestIsFieldArray` covers the function)
- [x] `grep regexp.MustCompile helpers/reflect.go` shows only the new package-level var
- [x] No other hot `regexp.MustCompile` in non-test code
- [x] Added `BenchmarkIsFieldArray` for regression tracking